### PR TITLE
[#38] Add GHC 9.2.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         ghc:
           - "8.10.7"
           - "9.0.2"
+          - "9.2.3"
 
     steps:
     - uses: actions/checkout@v3

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/uhbif19/colourista.git
+    tag: 8148a0446bf61814f79d6a0c497007fde72b31eb

--- a/iris.cabal
+++ b/iris.cabal
@@ -18,13 +18,14 @@ extra-doc-files:     README.md
                      CHANGELOG.md
 tested-with:         GHC == 8.10.7
                      GHC == 9.0.2
+                     GHC == 9.2.3
 
 source-repository head
   type:                git
   location:            https://github.com/chshersh/iris.git
 
 common common-options
-  build-depends:       base >= 4.14 && < 4.16
+  build-depends:       base >= 4.14 && < 4.17
 
   ghc-options:         -Wall
                        -Wcompat
@@ -46,6 +47,9 @@ common common-options
     ghc-options:       -Wunused-packages
   if impl(ghc >= 9.0)
     ghc-options:       -Winvalid-haddock
+  if impl(ghc >= 9.2)
+    ghc-options:       -Wredundant-bang-patterns
+                       -Woperator-whitespace
 
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds


### PR DESCRIPTION
The commit uses this [https://github.com/uhbif19/colourista/tree/bump-ghc](url) fork to resolve colourista dependency.

Resolves #38 