### PR TITLE
[#42] Support stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,15 @@ jobs:
           ghc: ["9.2.3"]
 
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: haskell/actions/setup@v1.2
+      - uses: haskell/actions/setup@v2.0
         name: Setup Haskell Stack
         with:
           ghc-version: ${{ matrix.ghc }}
           stack-version: ${{ matrix.stack }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache ~/.stack
         with:
           path: ~/.stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,38 @@ jobs:
     - name: Documentation
       run: |
         cabal haddock
+
+  stack:
+      name: stack / ghc ${{ matrix.ghc }}
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          stack: ["2.7.5"]
+          ghc: ["9.2.3"]
+
+      steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1.2
+        name: Setup Haskell Stack
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          stack-version: ${{ matrix.stack }}
+
+      - uses: actions/cache@v2
+        name: Cache ~/.stack
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+      - name: Install dependencies
+        run: |
+          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+
+      - name: Build
+        run: |
+          stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+
+      - name: Test
+        run: |
+          stack test --system-ghc

--- a/iris.cabal
+++ b/iris.cabal
@@ -124,7 +124,7 @@ test-suite iris-test
 
   build-depends:
     , iris
-    , hspec ^>= 2.10
+    , hspec >= 2.9.7 && < 2.11
     , text
 
   ghc-options:         -threaded

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,3 @@ resolver: nightly-2022-07-23
 extra-deps:
   - github: uhbif19/colourista
     commit: 8148a0446bf61814f79d6a0c497007fde72b31eb
-  - hspec-2.10.0@sha256:2d1dc53e361998f002497b7222fdb700cc540b2aaf880e2619a0b5d54abb74e5,1712
-  - hspec-core-2.10.0@sha256:a5d7d3e7bbcf42e8def370d86ab08252821be6fb9d00dddb3c484973d7a6e801,6617
-  - hspec-discover-2.10.0@sha256:517d0892217539969c199f9cc30065db7bcd68ff5512095e4f94ff8ef35d1313,2166

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,6 @@ resolver: nightly-2022-07-23
 extra-deps:
   - github: uhbif19/colourista
     commit: 8148a0446bf61814f79d6a0c497007fde72b31eb
+  - hspec-2.10.0@sha256:2d1dc53e361998f002497b7222fdb700cc540b2aaf880e2619a0b5d54abb74e5,1712
+  - hspec-core-2.10.0@sha256:a5d7d3e7bbcf42e8def370d86ab08252821be6fb9d00dddb3c484973d7a6e801,6617
+  - hspec-discover-2.10.0@sha256:517d0892217539969c199f9cc30065db7bcd68ff5512095e4f94ff8ef35d1313,2166

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: nightly-2022-07-23
+
+extra-deps:
+  - github: uhbif19/colourista
+    commit: 8148a0446bf61814f79d6a0c497007fde72b31eb


### PR DESCRIPTION
Uses [this](https://github.com/uhbif19/colourista/tree/bump-ghc) fork for colourista, and also some hspec versions are specified in extra-deps