### PR TITLE
[#84] Add support for GHC 9.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }} / cabal ${{ matrix.cabal }}
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.6", "3.8"]
+        cabal: ["3.8"]
         ghc:
           - "8.10.7"
           - "9.0.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,17 @@ on:
 
 jobs:
   cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }} / cabal ${{ matrix.cabal }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.6"]
+        cabal: ["3.6", "3.8"]
         ghc:
           - "8.10.7"
           - "9.0.2"
           - "9.2.4"
+          - "9.4.2"
 
         exclude:
           - os: macOS-latest
@@ -55,7 +56,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles('cabal.project.freeze') }}
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Install dependencies
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,1 @@
 packages: .
-
-source-repository-package
-    type: git
-    location: https://github.com/uhbif19/colourista.git
-    tag: 8148a0446bf61814f79d6a0c497007fde72b31eb

--- a/iris.cabal
+++ b/iris.cabal
@@ -25,7 +25,7 @@ source-repository head
   location:            https://github.com/chshersh/iris.git
 
 common common-options
-  build-depends:       base >= 4.14 && < 4.17
+  build-depends:       base >= 4.14 && < 4.18
 
   ghc-options:         -Wall
                        -Wcompat
@@ -109,7 +109,7 @@ executable iris-example
 
   build-depends:
      , iris
-     , colourista ^>= 0.1
+     , colourista >= 0.1.0.2
      , mtl
 
   ghc-options:         -threaded

--- a/iris.cabal
+++ b/iris.cabal
@@ -50,6 +50,8 @@ common common-options
   if impl(ghc >= 9.2)
     ghc-options:       -Wredundant-bang-patterns
                        -Woperator-whitespace
+  if impl(ghc >= 9.4)
+    ghc-options:       -Wredundant-strictness-flags
 
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds

--- a/iris.cabal
+++ b/iris.cabal
@@ -16,7 +16,8 @@ category:            CLI,Framework
 build-type:          Simple
 extra-doc-files:     README.md
                      CHANGELOG.md
-tested-with:         GHC == 9.2.4
+tested-with:         GHC == 9.4.2
+                     GHC == 9.2.4
                      GHC == 9.0.2
                      GHC == 8.10.7
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 resolver: nightly-2022-08-04
 
 extra-deps:
-  - github: uhbif19/colourista
-    commit: 8148a0446bf61814f79d6a0c497007fde72b31eb
+  - github: kowainik/colourista
+    commit: c7b06816ab85c27439fa7afbe6d5eed0506dd884

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
 resolver: nightly-2022-08-04
 
 extra-deps:
-  - github: kowainik/colourista
-    commit: c7b06816ab85c27439fa7afbe6d5eed0506dd884
+  - colourista-0.1.0.2


### PR DESCRIPTION
<!-- PR title template: [#ISSUE_NUMBER] <short description>
     Example:           [#42] Solve problem X
-->

Resolves #84

Adds support for GHC 9.4.2. Additionally, the `colourista` package declaration was updated so for cabal installs it uses the new hackage version (0.1.0.2) which supports 9.2.4, and also has a convenient base bound. For `stack`, I couldn't find a stackage for it, so I just pinned the commit from https://github.com/kowainik/colourista/commit/c7b06816ab85c27439fa7afbe6d5eed0506dd884

I also added Cabal 3.8 and GHC 9.4.2 to the build matrix for the cabal job. Let me know if we can just replace the existing cabal 3.6 with 3.8, or if it's okay to use both.

### Additional tasks

- [x] Documentation for changes provided/changed: Not needed
- [x] Tests added: Existing tests suffice.
- [x] Updated CHANGELOG.md: Should I do this?
