### PR TITLE
Resolves [#22] Add CLI options to handle colouring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ available [on GitHub][2].
 - [#89](https://github.com/chshersh/iris/issues/89)
   Add `putStderrColoured` and `putStdoutColoured` functions for putting string
   without output line breaking
+- [#22](https://github.com/chshersh/iris/issues/22):
+  Add CLI options to handle colouring
+  (by [@marcellourbani](https://github.com/marcellourbani))
+- [#58](https://github.com/chshersh/iris/issues/58):
+  Detect non-interactive terminals automatically
+  (by [@marcellourbani](https://github.com/marcellourbani))
 
 ## [0.0.0.0] — 2022-08-09 🌇
 
@@ -20,12 +26,6 @@ Initial release prepared by [@chshersh](https://github.com/chshersh).
 
 ### Added
 
-- [#22](https://github.com/chshersh/iris/issues/22):
-  Add CLI options to handle colouring
-  (by [@marcellourbani](https://github.com/marcellourbani))
-- [#58](https://github.com/chshersh/iris/issues/58):
-  Detect non-interactive terminals automatically
-  (by [@marcellourbani](https://github.com/marcellourbani))
 - [#34](https://github.com/chshersh/iris/issues/34):
   Add the `--no-input` CLI option for disabling interactivity
   (by [@charrsky](https://github.com/charrsky))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Initial release prepared by [@chshersh](https://github.com/chshersh).
 
 ### Added
 
+- [#22](https://github.com/chshersh/iris/issues/22):
+  Add CLI options to handle colouring
+  (by [@marcellourbani](https://github.com/marcellourbani))
+- [#58](https://github.com/chshersh/iris/issues/58):
+  Detect non-interactive terminals automatically
+  (by [@marcellourbani](https://github.com/marcellourbani))
 - [#34](https://github.com/chshersh/iris/issues/34):
   Add the `--no-input` CLI option for disabling interactivity
   (by [@charrsky](https://github.com/charrsky))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ CLI apps built with Iris offer the following features for end users:
     * `--version`
     * `--numeric-version`: helpful for detecting required tools versions
     * `--no-input`: for disabling all interactive features
-    * `--colour Colour_mode`: to set the colour mode. Can be `never`, `always` or `auto`
+    * `--colour`: to set colour mode
+    * `--no-colour`: to set non colour mode
 * Utilities to open files in a browser
 
 ## How to use?

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ CLI apps built with Iris offer the following features for end users:
     * `--version`
     * `--numeric-version`: helpful for detecting required tools versions
     * `--no-input`: for disabling all interactive features
-    * `--colour`: to set colour mode
-    * `--no-colour`: to set non colour mode
+    * `--colour=(auto|never|always)`: to set colour mode
+    * `--no-colour`: to disable terminal colouring
 * Utilities to open files in a browser
 
 ## How to use?

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ CLI apps built with Iris offer the following features for end users:
     * `--version`
     * `--numeric-version`: helpful for detecting required tools versions
     * `--no-input`: for disabling all interactive features
+    * `--colour Colour_mode`: to set the colour mode. Can be `never`, `always` or `auto`
 * Utilities to open files in a browser
 
 ## How to use?

--- a/iris.cabal
+++ b/iris.cabal
@@ -90,6 +90,8 @@ library
       Iris.Browse
       Iris.Cli
         Iris.Cli.Browse
+        Iris.Cli.Colour
+          Iris.Colour.Detect
         Iris.Cli.Internal
         Iris.Cli.Interactive
         Iris.Cli.ParserInfo
@@ -100,7 +102,6 @@ library
       Iris.Env
       Iris.Settings
       Iris.Tool
-
   build-depends:
     , ansi-terminal        ^>= 0.11
     , directory            ^>= 1.3

--- a/iris.cabal
+++ b/iris.cabal
@@ -95,6 +95,7 @@ library
         Iris.Cli.Interactive
         Iris.Cli.ParserInfo
         Iris.Cli.Version
+        Iris.Cli.TripleOption
       Iris.Colour
         Iris.Cli.Colour
           Iris.Colour.Detect

--- a/iris.cabal
+++ b/iris.cabal
@@ -90,13 +90,13 @@ library
       Iris.Browse
       Iris.Cli
         Iris.Cli.Browse
-        Iris.Cli.Colour
-          Iris.Colour.Detect
         Iris.Cli.Internal
         Iris.Cli.Interactive
         Iris.Cli.ParserInfo
         Iris.Cli.Version
       Iris.Colour
+        Iris.Cli.Colour
+          Iris.Colour.Detect
         Iris.Colour.Formatting
         Iris.Colour.Mode
       Iris.Env

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -1,0 +1,65 @@
+{- |
+Module                  : Iris.Cli.Colour
+Copyright               : (c) 2022 Dmitrii Kovanikov
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Dmitrii Kovanikov <kovanikov@gmail.com>
+Stability               : Experimental
+Portability             : Portable
+
+CLI options parsing for @--Colour@ and @--Colour=<FILE_PATH>@.
+
+@since x.x.x.x
+-}
+
+module Iris.Cli.Colour
+    ( ColourOption(..)
+    , colourModeP
+    ) where
+
+import Control.Applicative ((<|>))
+import qualified Options.Applicative as Opt
+
+
+{- | A CLI option parser for the requested colour mode
+
+@since x.x.x.x
+-}
+colourModeP :: Opt.Parser ColourOption
+colourModeP =  colour <|> color
+    where
+        colour = Opt.option colourModeReader $ mconcat
+            [ Opt.long "colour"
+            , Opt.metavar "Colour mode"
+            , Opt.help "Enable or disable colours"
+            ]
+        color = Opt.option colourModeReader $  Opt.long "color" <> Opt.internal
+        colourModeReader = Opt.str >>= readColourOption
+        readColourOption::String -> Opt.ReadM ColourOption
+        readColourOption = \case
+            "auto"   -> return AutoColour
+            "never"  -> return NeverColour
+            "always" -> return AlwaysColour
+            _        -> Opt.readerError "Accepted colour modes are 'always', 'never' and 'auto'."
+
+{- | Data type that tells whether the user wants colouring
+enabled, disabled or autodetected.
+
+Actual colour mode might also depend on environment variables
+like NO_COLOR / NO_COLOUR or <MY_APP_NAME>_NO_COLOR / <MY_APP_NAME>_NO_COLOUR
+
+@since x.x.x.x
+-}
+data ColourOption
+    -- | @since x.x.x.x
+    = AlwaysColour
+
+    -- | @since x.x.x.x
+    | NeverColour
+    | AutoColour
+    deriving stock
+        ( Show     -- ^ @since x.x.x.x
+        , Eq       -- ^ @since x.x.x.x
+        , Ord      -- ^ @since x.x.x.x
+        , Enum     -- ^ @since x.x.x.x
+        , Bounded  -- ^ @since x.x.x.x
+        )

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -52,7 +52,7 @@ colourModeP =  colour <|> color <|> pure AutoColour
     where
         colour = Opt.option colourModeReader $ mconcat
             [ Opt.long "colour"
-            , Opt.metavar "Colour mode"
+            , Opt.metavar "Colour_mode"
             , Opt.help "Enable or disable colours"
             ]
         color = Opt.option colourModeReader $  Opt.long "color" <> Opt.internal

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -17,6 +17,7 @@ module Iris.Cli.Colour
     ) where
 
 import Control.Applicative ((<|>))
+import Data.Functor (($>))
 import qualified Options.Applicative as Opt
 
 
@@ -48,18 +49,15 @@ data ColourOption
 @since x.x.x.x
 -}
 colourModeP :: Opt.Parser ColourOption
-colourModeP =  colour <|> color <|> pure AutoColour
+colourModeP =  colour <|> nocoulor <|> pure AutoColour
     where
-        colour = Opt.option colourModeReader $ mconcat
-            [ Opt.long "colour"
-            , Opt.metavar "Colour_mode"
-            , Opt.help "Enable or disable colours"
-            ]
-        color = Opt.option colourModeReader $  Opt.long "color" <> Opt.internal
-        colourModeReader = Opt.str >>= readColourOption
-        readColourOption::String -> Opt.ReadM ColourOption
-        readColourOption = \case
-            "auto"   -> return AutoColour
-            "never"  -> return NeverColour
-            "always" -> return AlwaysColour
-            _        -> Opt.readerError "Accepted colour modes are 'always', 'never' and 'auto'."
+        colour = (
+                Opt.flag' AlwaysColour ( Opt.long "colour" <> Opt.help "Enable colours")
+            <|> Opt.flag' AlwaysColour ( Opt.long "color" <> Opt.internal)
+            ) $> AlwaysColour
+        nocoulor = (
+                Opt.flag' AlwaysColour ( Opt.long "no-colour" <> Opt.help "Disable colours")
+            <|> Opt.flag' AlwaysColour ( Opt.long "no-color" <> Opt.internal)
+            <|> Opt.flag' AlwaysColour ( Opt.long "disable-color" <> Opt.internal)
+            <|> Opt.flag' AlwaysColour ( Opt.long "disable-coulor" <> Opt.internal)
+            ) $> NeverColour

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -35,6 +35,8 @@ data ColourOption
 
     -- | @since x.x.x.x
     | NeverColour
+
+    -- | @since x.x.x.x
     | AutoColour
     deriving stock
         ( Show     -- ^ @since x.x.x.x

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -12,54 +12,29 @@ CLI options parsing for @--Colour@ and @--Colour=<FILE_PATH>@.
 -}
 
 module Iris.Cli.Colour
-    ( ColourOption(..)
-    , colourModeP
+    ( colourModeP
     ) where
 
 import Control.Applicative ((<|>))
 import Data.Functor (($>))
+import Iris.Cli.TripleOption
 import qualified Options.Applicative as Opt
 
-
-{- | Data type that tells whether the user wants colouring
-enabled, disabled or autodetected.
-
-Actual colour mode might also depend on environment variables
-like NO_COLOR / NO_COLOUR or <MY_APP_NAME>_NO_COLOR / <MY_APP_NAME>_NO_COLOUR
-
-@since x.x.x.x
--}
-data ColourOption
-    -- | @since x.x.x.x
-    = AlwaysColour
-
-    -- | @since x.x.x.x
-    | NeverColour
-
-    -- | @since x.x.x.x
-    | AutoColour
-    deriving stock
-        ( Show     -- ^ @since x.x.x.x
-        , Eq       -- ^ @since x.x.x.x
-        , Ord      -- ^ @since x.x.x.x
-        , Enum     -- ^ @since x.x.x.x
-        , Bounded  -- ^ @since x.x.x.x
-        )
 
 {- | A CLI option parser for the requested colour mode
 
 @since x.x.x.x
 -}
-colourModeP :: Opt.Parser ColourOption
-colourModeP =  colour <|> nocoulor <|> pure AutoColour
+colourModeP :: Opt.Parser TripleOption
+colourModeP =  colour <|> nocoulor <|> pure TOAuto
     where
         colour = (
-                Opt.flag' AlwaysColour ( Opt.long "colour" <> Opt.help "Enable colours")
-            <|> Opt.flag' AlwaysColour ( Opt.long "color" <> Opt.internal)
-            ) $> AlwaysColour
+                Opt.flag' TOAlways ( Opt.long "colour" <> Opt.help "Enable colours")
+            <|> Opt.flag' TOAlways ( Opt.long "color" <> Opt.internal)
+            ) $> TOAlways
         nocoulor = (
-                Opt.flag' AlwaysColour ( Opt.long "no-colour" <> Opt.help "Disable colours")
-            <|> Opt.flag' AlwaysColour ( Opt.long "no-color" <> Opt.internal)
-            <|> Opt.flag' AlwaysColour ( Opt.long "disable-color" <> Opt.internal)
-            <|> Opt.flag' AlwaysColour ( Opt.long "disable-coulor" <> Opt.internal)
-            ) $> NeverColour
+                Opt.flag' TOAlways ( Opt.long "no-colour" <> Opt.help "Disable colours")
+            <|> Opt.flag' TOAlways ( Opt.long "no-color" <> Opt.internal)
+            <|> Opt.flag' TOAlways ( Opt.long "disable-color" <> Opt.internal)
+            <|> Opt.flag' TOAlways ( Opt.long "disable-coulor" <> Opt.internal)
+            ) $> TONever

--- a/src/Iris/Cli/Colour.hs
+++ b/src/Iris/Cli/Colour.hs
@@ -20,27 +20,6 @@ import Control.Applicative ((<|>))
 import qualified Options.Applicative as Opt
 
 
-{- | A CLI option parser for the requested colour mode
-
-@since x.x.x.x
--}
-colourModeP :: Opt.Parser ColourOption
-colourModeP =  colour <|> color
-    where
-        colour = Opt.option colourModeReader $ mconcat
-            [ Opt.long "colour"
-            , Opt.metavar "Colour mode"
-            , Opt.help "Enable or disable colours"
-            ]
-        color = Opt.option colourModeReader $  Opt.long "color" <> Opt.internal
-        colourModeReader = Opt.str >>= readColourOption
-        readColourOption::String -> Opt.ReadM ColourOption
-        readColourOption = \case
-            "auto"   -> return AutoColour
-            "never"  -> return NeverColour
-            "always" -> return AlwaysColour
-            _        -> Opt.readerError "Accepted colour modes are 'always', 'never' and 'auto'."
-
 {- | Data type that tells whether the user wants colouring
 enabled, disabled or autodetected.
 
@@ -63,3 +42,24 @@ data ColourOption
         , Enum     -- ^ @since x.x.x.x
         , Bounded  -- ^ @since x.x.x.x
         )
+
+{- | A CLI option parser for the requested colour mode
+
+@since x.x.x.x
+-}
+colourModeP :: Opt.Parser ColourOption
+colourModeP =  colour <|> color <|> pure AutoColour
+    where
+        colour = Opt.option colourModeReader $ mconcat
+            [ Opt.long "colour"
+            , Opt.metavar "Colour mode"
+            , Opt.help "Enable or disable colours"
+            ]
+        color = Opt.option colourModeReader $  Opt.long "color" <> Opt.internal
+        colourModeReader = Opt.str >>= readColourOption
+        readColourOption::String -> Opt.ReadM ColourOption
+        readColourOption = \case
+            "auto"   -> return AutoColour
+            "never"  -> return NeverColour
+            "always" -> return AlwaysColour
+            _        -> Opt.readerError "Accepted colour modes are 'always', 'never' and 'auto'."

--- a/src/Iris/Cli/Internal.hs
+++ b/src/Iris/Cli/Internal.hs
@@ -17,6 +17,7 @@ module Iris.Cli.Internal
     ) where
 
 import Data.Kind (Type)
+import Iris.Cli.Colour
 import Iris.Cli.Interactive (InteractiveMode)
 
 {- |
@@ -26,5 +27,6 @@ Wrapper around @cmd@ with additional predefined fields
 
 data Cmd (cmd :: Type) = Cmd
     { cmdInteractiveMode :: InteractiveMode
-    , cmdCmd :: cmd
+    , cmdColourOption    :: ColourOption
+    , cmdCmd             :: cmd
     }

--- a/src/Iris/Cli/Internal.hs
+++ b/src/Iris/Cli/Internal.hs
@@ -17,8 +17,8 @@ module Iris.Cli.Internal
     ) where
 
 import Data.Kind (Type)
-import Iris.Cli.Colour
 import Iris.Cli.Interactive (InteractiveMode)
+import Iris.Cli.TripleOption
 
 {- |
 
@@ -27,6 +27,6 @@ Wrapper around @cmd@ with additional predefined fields
 
 data Cmd (cmd :: Type) = Cmd
     { cmdInteractiveMode :: InteractiveMode
-    , cmdColourOption    :: ColourOption
+    , cmdColourOption    :: TripleOption
     , cmdCmd             :: cmd
     }

--- a/src/Iris/Cli/ParserInfo.hs
+++ b/src/Iris/Cli/ParserInfo.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE ApplicativeDo    #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ApplicativeDo #-}
 
 {- |
 Module                  : Iris.Cli.ParserInfo
@@ -16,11 +16,12 @@ Parser information for the default CLI parser.
 
 module Iris.Cli.ParserInfo (cmdParserInfo) where
 
-import Iris.Cli.Internal ( Cmd (..) )
 import Iris.Cli.Interactive (interactiveModeP)
-import Iris.Settings (CliEnvSettings (..))
+import Iris.Cli.Internal (Cmd (..))
 import Iris.Cli.Version (mkVersionParser)
+import Iris.Settings (CliEnvSettings (..))
 
+import Iris.Cli.Colour (colourModeP)
 import qualified Options.Applicative as Opt
 
 {- |
@@ -44,5 +45,6 @@ cmdParserInfo CliEnvSettings{..} = Opt.info
     cmdP = do
       cmdInteractiveMode <- interactiveModeP
       cmdCmd <- cliEnvSettingsCmdParser
+      cmdColourOption <- colourModeP
 
       pure Cmd{..}

--- a/src/Iris/Cli/TripleOption.hs
+++ b/src/Iris/Cli/TripleOption.hs
@@ -1,0 +1,37 @@
+{- |
+Module                  : Iris.Cli.TripleOption
+Copyright               : (c) 2022 Dmitrii Kovanikov
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Dmitrii Kovanikov <kovanikov@gmail.com>
+Stability               : Experimental
+Portability             : Portable
+
+CLI options parsing for @--Colour@ and @--Colour=<FILE_PATH>@.
+
+@since x.x.x.x
+-}
+
+module Iris.Cli.TripleOption
+    ( TripleOption(..)) where
+
+{- | Data type that tells whether the user wants an option
+enabled, disabled or autodetected.
+
+@since x.x.x.x
+-}
+data TripleOption
+    -- | @since x.x.x.x
+    = TOAlways
+
+    -- | @since x.x.x.x
+    | TONever
+
+    -- | @since x.x.x.x
+    | TOAuto
+    deriving stock
+        ( Show     -- ^ @since x.x.x.x
+        , Eq       -- ^ @since x.x.x.x
+        , Ord      -- ^ @since x.x.x.x
+        , Enum     -- ^ @since x.x.x.x
+        , Bounded  -- ^ @since x.x.x.x
+        )

--- a/src/Iris/Colour/Detect.hs
+++ b/src/Iris/Colour/Detect.hs
@@ -1,7 +1,6 @@
 {- |
 Module                  : Iris.Colour.Detect
-Copyright               : (c) 2020 Kowainik
-                          (c) 2022 Dmitrii Kovanikov
+Copyright               : (c) 2022 Dmitrii Kovanikov
 SPDX-License-Identifier : MPL-2.0
 Maintainer              : Dmitrii Kovanikov <kovanikov@gmail.com>
 Stability               : Experimental

--- a/src/Iris/Colour/Detect.hs
+++ b/src/Iris/Colour/Detect.hs
@@ -12,16 +12,21 @@ Detects if colour should be enabled or not
 -}
 
 module Iris.Colour.Detect
-    ( detectColour
+    ( detectColourDisabled
     ) where
+import Data.Char (toLower)
 import System.Environment (lookupEnv)
 
 
-
-detectColour :: Maybe String -> IO Bool
-detectColour appname = any  (/= Nothing) <$> traverse lookupEnv varnames
+detectColourDisabled :: Maybe String -> IO Bool
+detectColourDisabled maybeAppName = do
+      nocolour <-  any  (/= Nothing) <$> traverse lookupEnv varnames
+      term <- lookupEnv "TERM"
+      let dumb = (map toLower <$> term) == Just "dumb"
+      return $ dumb || nocolour
   where
     basevarnames = ["NO_COLOR","NO_COLOUR"]
-    varnames = case (<> "_") <$> appname of
-        Nothing -> basevarnames
-        Just n  -> ((n <>) <$> basevarnames) <> basevarnames
+    prepend appName envName = appName <> "_" <> envName
+    varnames = case maybeAppName of
+        Nothing      -> basevarnames
+        Just appName -> basevarnames <> (prepend appName <$> basevarnames)

--- a/src/Iris/Colour/Detect.hs
+++ b/src/Iris/Colour/Detect.hs
@@ -1,0 +1,28 @@
+{- |
+Module                  : Iris.Colour.Detect
+Copyright               : (c) 2020 Kowainik
+                          (c) 2022 Dmitrii Kovanikov
+SPDX-License-Identifier : MPL-2.0
+Maintainer              : Dmitrii Kovanikov <kovanikov@gmail.com>
+Stability               : Experimental
+Portability             : Portable
+
+Detects if colour should be enabled or not
+
+@since x.x.x.x
+-}
+
+module Iris.Colour.Detect
+    ( detectColour
+    ) where
+import System.Environment (lookupEnv)
+
+
+
+detectColour :: Maybe String -> IO Bool
+detectColour appname = any  (/= Nothing) <$> traverse lookupEnv varnames
+  where
+    basevarnames = ["NO_COLOR","NO_COLOUR"]
+    varnames = case (<> "_") <$> appname of
+        Nothing -> basevarnames
+        Just n  -> ((n <>) <$> basevarnames) <> basevarnames

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -16,6 +16,7 @@ colouring.
 module Iris.Colour.Mode
     ( ColourMode (..)
     , handleColourMode
+    , actualHandleColourMode
     ) where
 
 import Iris.Cli.Colour
@@ -44,9 +45,9 @@ data ColourMode
         , Bounded  -- ^ @since 0.0.0.0
         )
 
-{- | Returns 'ColourMode' of a 'Handle'. You can use this function on
-output 'Handle's to find out whether they support colouring or
-not.
+{- | Returns 'ColourMode' of a 'Handle' ignoring environment and CLI options.
+You can use this function on output 'Handle's to find out whether they support
+colouring or not.
 
 Use a function like this to check whether you can print with colour
 to terminal:
@@ -57,16 +58,34 @@ to terminal:
 
 @since 0.0.0.0
 -}
-handleColourMode :: Maybe String -> ColourOption -> Handle ->  IO ColourMode
-handleColourMode app colourOption handle = do
+handleColourMode :: Handle -> IO ColourMode
+handleColourMode handle = do
     supportsANSI <- hSupportsANSIColor handle
+    pure $ if supportsANSI then EnableColour else DisableColour
+
+{- | Returns 'ColourMode' of a 'Handle' accounting for environment and CLI
+options. You can use this function on output 'Handle's to find out whether
+they support colouring or not.
+
+Use a function like this to check whether you can print with colour
+to terminal:
+
+@
+'handleColourMode' '(Just myappname)' 'AutoColour' 'System.IO.stdout'
+@
+
+@since x.x.x.x
+-}
+actualHandleColourMode :: Maybe String -> ColourOption -> Handle ->  IO ColourMode
+actualHandleColourMode app colourOption handle = do
+    handleMode <- handleColourMode handle
     colourDisabled <- detectColour app
-    pure $ case (supportsANSI,colourOption,colourDisabled) of
-        (False,_,_)        -> DisableColour
-        (_,AlwaysColour,_) -> EnableColour
-        (_,NeverColour,_)  -> DisableColour
-        (_,_,True)         -> EnableColour
-        (_,_,False)        -> DisableColour
+    pure $ case (handleMode,colourOption,colourDisabled) of
+        (DisableColour,_,_) -> DisableColour
+        (_,AlwaysColour,_)  -> EnableColour
+        (_,NeverColour,_)   -> DisableColour
+        (_,_,True)          -> EnableColour
+        (_,_,False)         -> DisableColour
 
 {-
 ------------------------

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -20,7 +20,7 @@ module Iris.Colour.Mode
     ) where
 
 import Iris.Cli.Colour
-import Iris.Colour.Detect (detectColour)
+import Iris.Colour.Detect (detectColourDisabled)
 import System.Console.ANSI (hSupportsANSIColor)
 import System.IO (Handle)
 
@@ -79,7 +79,7 @@ to terminal:
 actualHandleColourMode :: Maybe String -> ColourOption -> Handle ->  IO ColourMode
 actualHandleColourMode app colourOption handle = do
     handleMode <- handleColourMode handle
-    colourDisabled <- detectColour app
+    colourDisabled <- detectColourDisabled app
     pure $ case (handleMode,colourOption,colourDisabled) of
         (DisableColour,_,_) -> DisableColour
         (_,AlwaysColour,_)  -> EnableColour

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -84,8 +84,8 @@ actualHandleColourMode app colourOption handle = do
         (DisableColour,_,_) -> DisableColour
         (_,AlwaysColour,_)  -> EnableColour
         (_,NeverColour,_)   -> DisableColour
-        (_,_,True)          -> EnableColour
-        (_,_,False)         -> DisableColour
+        (_,_,True)          -> DisableColour
+        (_,_,False)         -> EnableColour
 
 {-
 ------------------------

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -18,6 +18,8 @@ module Iris.Colour.Mode
     , handleColourMode
     ) where
 
+import Iris.Cli.Colour
+import Iris.Colour.Detect (detectColour)
 import System.Console.ANSI (hSupportsANSIColor)
 import System.IO (Handle)
 
@@ -55,10 +57,16 @@ to terminal:
 
 @since 0.0.0.0
 -}
-handleColourMode :: Handle -> IO ColourMode
-handleColourMode handle = do
+handleColourMode :: Maybe String -> ColourOption -> Handle ->  IO ColourMode
+handleColourMode app colourOption handle = do
     supportsANSI <- hSupportsANSIColor handle
-    pure $ if supportsANSI then EnableColour else DisableColour
+    colourDisabled <- detectColour app
+    pure $ case (supportsANSI,colourOption,colourDisabled) of
+        (False,_,_)        -> DisableColour
+        (_,AlwaysColour,_) -> EnableColour
+        (_,NeverColour,_)  -> DisableColour
+        (_,_,True)         -> EnableColour
+        (_,_,False)        -> DisableColour
 
 {-
 ------------------------

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -19,7 +19,6 @@ module Iris.Colour.Mode
     , actualHandleColourMode
     ) where
 
-import Iris.Cli.Colour
 import Iris.Cli.TripleOption
 import Iris.Colour.Detect (detectColourDisabled)
 import System.Console.ANSI (hSupportsANSIColor)

--- a/src/Iris/Colour/Mode.hs
+++ b/src/Iris/Colour/Mode.hs
@@ -20,6 +20,7 @@ module Iris.Colour.Mode
     ) where
 
 import Iris.Cli.Colour
+import Iris.Cli.TripleOption
 import Iris.Colour.Detect (detectColourDisabled)
 import System.Console.ANSI (hSupportsANSIColor)
 import System.IO (Handle)
@@ -76,14 +77,14 @@ to terminal:
 
 @since x.x.x.x
 -}
-actualHandleColourMode :: Maybe String -> ColourOption -> Handle ->  IO ColourMode
+actualHandleColourMode :: Maybe String -> TripleOption -> Handle ->  IO ColourMode
 actualHandleColourMode app colourOption handle = do
     handleMode <- handleColourMode handle
     colourDisabled <- detectColourDisabled app
     pure $ case (handleMode,colourOption,colourDisabled) of
         (DisableColour,_,_) -> DisableColour
-        (_,AlwaysColour,_)  -> EnableColour
-        (_,NeverColour,_)   -> DisableColour
+        (_,TOAlways,_)      -> EnableColour
+        (_,TONever,_)       -> DisableColour
         (_,_,True)          -> DisableColour
         (_,_,False)         -> EnableColour
 

--- a/src/Iris/Env.hs
+++ b/src/Iris/Env.hs
@@ -37,7 +37,7 @@ import System.IO (stderr, stdout)
 import Iris.Cli.Interactive (InteractiveMode, handleInteractiveMode)
 import Iris.Cli.Internal (Cmd (..))
 import Iris.Cli.ParserInfo (cmdParserInfo)
-import Iris.Colour.Mode (ColourMode, handleColourMode)
+import Iris.Colour.Mode (ColourMode, actualHandleColourMode)
 import Iris.Settings (CliEnvSettings (..))
 import Iris.Tool (ToolCheckError (..), ToolCheckResult (..), checkTool)
 
@@ -116,8 +116,8 @@ mkCliEnv
     -> IO (CliEnv cmd appEnv)
 mkCliEnv cliEnvSettings@CliEnvSettings{..} = do
     Cmd{..} <- Opt.execParser $ cmdParserInfo cliEnvSettings
-    stdoutColourMode <- handleColourMode cliEnvSettingsAppName cmdColourOption stdout
-    stderrColourMode <- handleColourMode cliEnvSettingsAppName cmdColourOption stderr
+    stdoutColourMode <- actualHandleColourMode cliEnvSettingsAppName cmdColourOption stdout
+    stderrColourMode <- actualHandleColourMode cliEnvSettingsAppName cmdColourOption stderr
     interactive <- handleInteractiveMode cmdInteractiveMode
 
     for_ cliEnvSettingsRequiredTools $ \tool ->

--- a/src/Iris/Env.hs
+++ b/src/Iris/Env.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE ApplicativeDo    #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ApplicativeDo #-}
 
 {- |
 Module                  : Iris.Env
@@ -34,12 +34,12 @@ import Data.Foldable (for_)
 import Data.Kind (Type)
 import System.IO (stderr, stdout)
 
+import Iris.Cli.Interactive (InteractiveMode, handleInteractiveMode)
 import Iris.Cli.Internal (Cmd (..))
 import Iris.Cli.ParserInfo (cmdParserInfo)
-import Iris.Cli.Interactive (InteractiveMode, handleInteractiveMode)
 import Iris.Colour.Mode (ColourMode, handleColourMode)
 import Iris.Settings (CliEnvSettings (..))
-import Iris.Tool (ToolCheckResult (..), checkTool, ToolCheckError (..))
+import Iris.Tool (ToolCheckError (..), ToolCheckResult (..), checkTool)
 
 import qualified Options.Applicative as Opt
 
@@ -116,13 +116,13 @@ mkCliEnv
     -> IO (CliEnv cmd appEnv)
 mkCliEnv cliEnvSettings@CliEnvSettings{..} = do
     Cmd{..} <- Opt.execParser $ cmdParserInfo cliEnvSettings
-    stdoutColourMode <- handleColourMode stdout
-    stderrColourMode <- handleColourMode stderr
+    stdoutColourMode <- handleColourMode cliEnvSettingsAppName cmdColourOption stdout
+    stderrColourMode <- handleColourMode cliEnvSettingsAppName cmdColourOption stderr
     interactive <- handleInteractiveMode cmdInteractiveMode
 
     for_ cliEnvSettingsRequiredTools $ \tool ->
         checkTool cmdCmd tool >>= \case
-            ToolOk  -> pure ()
+            ToolOk                   -> pure ()
             (ToolCheckError toolErr) -> throwIO $ CliEnvException $ CliEnvToolError toolErr
 
     pure CliEnv

--- a/src/Iris/Settings.hs
+++ b/src/Iris/Settings.hs
@@ -43,6 +43,7 @@ data CliEnvSettings (cmd :: Type) (appEnv :: Type) = CliEnvSettings
       -- | @since 0.0.0.0
     , cliEnvSettingsVersionSettings :: Maybe VersionSettings
 
+    , cliEnvSettingsAppName :: Maybe String
       -- | @since 0.0.0.0
     , cliEnvSettingsRequiredTools   :: [Tool cmd]
     }
@@ -59,5 +60,6 @@ defaultCliEnvSettings = CliEnvSettings
     , cliEnvSettingsHeaderDesc      = "Simple CLI program"
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
     , cliEnvSettingsVersionSettings = Nothing
+    , cliEnvSettingsAppName         = Nothing
     , cliEnvSettingsRequiredTools   = []
     }

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -108,7 +108,7 @@ cliSpec = describe "Cli Options" $ do
         setEnv "MYAPP_NO_COLOUR" "TRUE"
         detectColourDisabled (Just "MYAPP") `shouldReturn` True
         detectColourDisabled Nothing `shouldReturn` False
-    it "Disables colour on dumb terminals" $do
+    it "Disables colour on dumb terminals" $ do
         clearAppEnv
         setEnv "TERM" "NOTDUMB"
         detectColourDisabled (Just "MYAPP") `shouldReturn` False

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -5,10 +5,10 @@ import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, shouldBe
 
 import Iris (CliEnvSettings (..))
 import Iris.Cli (VersionSettings (versionSettingsMkDesc))
-import Iris.Cli.Colour (ColourOption (..))
 import Iris.Cli.Interactive (InteractiveMode (..), handleInteractiveMode)
 import Iris.Cli.Internal
 import Iris.Cli.ParserInfo (cmdParserInfo)
+import Iris.Cli.TripleOption (TripleOption (..))
 import Iris.Cli.Version (defaultVersionSettings)
 import Iris.Colour.Detect (detectColourDisabled)
 import Iris.Colour.Mode (ColourMode (..), actualHandleColourMode)
@@ -85,9 +85,9 @@ cliSpec = describe "Cli Options" $ do
     it "Handles colour mode" $ do
         let parserInfo = cmdParserInfo defaultCliEnvSettings
         let coloption args = getParseResult $ cmdColourOption <$> Opt.execParserPure parserPrefs parserInfo args
-        coloption ["--colour"] `shouldBe` pure AlwaysColour
-        coloption ["--no-colour"] `shouldBe` pure NeverColour
-        coloption [] `shouldBe` pure AutoColour
+        coloption ["--colour"] `shouldBe` pure TOAlways
+        coloption ["--no-colour"] `shouldBe` pure TONever
+        coloption [] `shouldBe` pure TOAuto
     it "Applies base nocolour environment" $ do
         clearAppEnv
         detectColourDisabled (Just "MYAPP") `shouldReturn` False
@@ -124,12 +124,12 @@ cliSpec = describe "Cli Options" $ do
         isCi <- checkCI
         clearAppEnv
         let ciColour = if isCi then DisableColour else EnableColour
-        actualHandleColourMode (Just "MYAPP") NeverColour stdout `shouldReturn` DisableColour
-        actualHandleColourMode (Just "MYAPP") AlwaysColour stdout `shouldReturn` ciColour
-        actualHandleColourMode (Just "MYAPP") AutoColour stdout `shouldReturn` ciColour
+        actualHandleColourMode (Just "MYAPP") TONever stdout `shouldReturn` DisableColour
+        actualHandleColourMode (Just "MYAPP") TOAlways stdout `shouldReturn` ciColour
+        actualHandleColourMode (Just "MYAPP") TOAuto stdout `shouldReturn` ciColour
         setEnv "NO_COLOUR" "TRUE"
-        actualHandleColourMode (Just "MYAPP") AutoColour stdout `shouldReturn` DisableColour
-        actualHandleColourMode (Just "MYAPP") AlwaysColour stdout `shouldReturn` ciColour
+        actualHandleColourMode (Just "MYAPP") TOAuto stdout `shouldReturn` DisableColour
+        actualHandleColourMode (Just "MYAPP") TOAlways stdout `shouldReturn` ciColour
     it "--version returns correct version text" $ do
         let expectedVersionMkDescription = ("Version " ++)
         let cliEnvSettings = defaultCliEnvSettings { cliEnvSettingsVersionSettings = Just $ (defaultVersionSettings Autogen.version) {versionSettingsMkDesc  = expectedVersionMkDescription}}

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -12,7 +12,8 @@ import Iris.Cli.ParserInfo (cmdParserInfo)
 import Iris.Cli.Version (defaultVersionSettings)
 import Iris.Colour.Detect (detectColour)
 import Iris.Colour.Mode (ColourMode (..), actualHandleColourMode)
-import Iris.Settings (cliEnvSettingsVersionSettings, defaultCliEnvSettings)
+import Iris.Settings (defaultCliEnvSettings)
+import Options.Applicative (getParseResult)
 import qualified Options.Applicative as Opt
 import qualified Paths_iris as Autogen
 import System.Environment (lookupEnv, setEnv)
@@ -26,21 +27,22 @@ expectedHelpText :: String
 expectedHelpText =
     "Simple CLI program\n\
     \\n\
-    \Usage: <iris-test> [--no-input] [--colour Colour_mode]\n\
+    \Usage: <iris-test> [--no-input] [--colour | --no-colour]\n\
     \\n\
     \  CLI tool build with iris - a Haskell CLI framework\n\
     \\n\
     \Available options:\n\
     \  -h,--help                Show this help text\n\
     \  --no-input               Enter the terminal in non-interactive mode\n\
-    \  --colour Colour_mode     Enable or disable colours"
+    \  --colour                 Enable colours\n\
+    \  --no-colour              Disable colours"
 
 expectedHelpTextWithVersion :: String
 expectedHelpTextWithVersion =
     "Simple CLI program\n\
     \\n\
     \Usage: <iris-test> [--version] [--numeric-version] [--no-input] \n\
-    \                   [--colour Colour_mode]\n\
+    \                   [--colour | --no-colour]\n\
     \\n\
     \  CLI tool build with iris - a Haskell CLI framework\n\
     \\n\
@@ -49,7 +51,8 @@ expectedHelpTextWithVersion =
     \  --version                Show application version\n\
     \  --numeric-version        Show only numeric application version\n\
     \  --no-input               Enter the terminal in non-interactive mode\n\
-    \  --colour Colour_mode     Enable or disable colours"
+    \  --colour                 Enable colours\n\
+    \  --no-colour              Disable colours"
 
 expectedNumericVersion :: String
 expectedNumericVersion = "0.0.0.0"
@@ -79,6 +82,12 @@ cliSpec = describe "Cli Options" $ do
         isCi <- checkCI
         if isCi then handleInteractiveMode Interactive `shouldReturn` NonInteractive
         else handleInteractiveMode Interactive `shouldReturn` Interactive
+    it "Handles colour mode" $ do
+        let parserInfo = cmdParserInfo defaultCliEnvSettings
+        let coloption args = getParseResult $ cmdColourOption <$> Opt.execParserPure parserPrefs parserInfo args
+        coloption ["--colour"] `shouldBe` pure AlwaysColour
+        coloption ["--no-colour"] `shouldBe` pure NeverColour
+        coloption [] `shouldBe` pure AutoColour
     it "Applies base nocolour environment" $ do
         clearAppEnv
         detectColour (Just "MYAPP") `shouldReturn` False
@@ -151,7 +160,7 @@ expectedErrorTextUserDefinedNoInputArg :: String
 expectedErrorTextUserDefinedNoInputArg =
   "Invalid argument `" <> argValue <> "'\n\
   \\n\
-  \Usage: <iris-test> [--no-input] --no-input ARG\n\
+  \Usage: <iris-test> [--no-input] --no-input ARG [--colour | --no-colour]\n\
   \\n\
   \  CLI tool build with iris - a Haskell CLI framework"
 
@@ -159,7 +168,7 @@ expectedErrorTextUserDefinedNoInputNoArg :: String
 expectedErrorTextUserDefinedNoInputNoArg =
   "Missing: --no-input ARG\n\
   \\n\
-  \Usage: <iris-test> [--no-input] --no-input ARG\n\
+  \Usage: <iris-test> [--no-input] --no-input ARG [--colour | --no-colour]\n\
   \\n\
   \  CLI tool build with iris - a Haskell CLI framework"
 

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -3,12 +3,13 @@ module Test.Iris.Cli (cliSpec, cliSpecParserConflicts) where
 
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, shouldBe, shouldReturn)
 
+import Iris (CliEnvSettings (..))
 import Iris.Cli (VersionSettings (versionSettingsMkDesc))
 import Iris.Cli.Interactive (InteractiveMode (..), handleInteractiveMode)
 import Iris.Cli.Internal
 import Iris.Cli.ParserInfo (cmdParserInfo)
 import Iris.Cli.Version (defaultVersionSettings)
-import Iris.Settings (CliEnvSettings (..), defaultCliEnvSettings)
+import Iris.Settings (cliEnvSettingsVersionSettings, defaultCliEnvSettings)
 import qualified Options.Applicative as Opt
 import qualified Paths_iris as Autogen
 import System.Environment (lookupEnv)
@@ -21,19 +22,21 @@ expectedHelpText :: String
 expectedHelpText =
     "Simple CLI program\n\
     \\n\
-    \Usage: <iris-test> [--no-input]\n\
+    \Usage: <iris-test> [--no-input] [--colour Colour mode]\n\
     \\n\
     \  CLI tool build with iris - a Haskell CLI framework\n\
     \\n\
     \Available options:\n\
     \  -h,--help                Show this help text\n\
-    \  --no-input               Enter the terminal in non-interactive mode"
+    \  --no-input               Enter the terminal in non-interactive mode\n\
+    \  --colour Colour mode     Enable or disable colours"
 
 expectedHelpTextWithVersion :: String
 expectedHelpTextWithVersion =
     "Simple CLI program\n\
     \\n\
-    \Usage: <iris-test> [--version] [--numeric-version] [--no-input]\n\
+    \Usage: <iris-test> [--version] [--numeric-version] [--no-input] \n\
+    \                   [--colour Colour mode]\n\
     \\n\
     \  CLI tool build with iris - a Haskell CLI framework\n\
     \\n\
@@ -41,7 +44,8 @@ expectedHelpTextWithVersion =
     \  -h,--help                Show this help text\n\
     \  --version                Show application version\n\
     \  --numeric-version        Show only numeric application version\n\
-    \  --no-input               Enter the terminal in non-interactive mode"
+    \  --no-input               Enter the terminal in non-interactive mode\n\
+    \  --colour Colour mode     Enable or disable colours"
 
 expectedNumericVersion :: String
 expectedNumericVersion = "0.0.0.0"
@@ -100,6 +104,7 @@ customParserSettings parser = CliEnvSettings
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
     , cliEnvSettingsVersionSettings = Nothing
     , cliEnvSettingsRequiredTools   = []
+    , cliEnvSettingsAppName         = Nothing
     }
 
 argValue :: String


### PR DESCRIPTION
Resolves #22

* [X]  Add a config option for my application name
* [X]  Add new module `Iris.Cli.Colour`
*   * [X]  Enum type for `always` / `auto` / `never` options
  * [X]  CLI parsers for above-mentioned colours
  * [X]  Add this option by default to env
* [X]  Add a new module `Iris.Colour.Detect` with the implementation of the colouring detection logic described in the beginning of this issue
* [X]  There should be no separate option for `stdout` and `stderr`. In other words, env variables and CLI disable / enable 

I had to change expectations of some tests in cliSpecParserConflicts to account for the new options, I wonde if they can be made more robust

Also, I guess I should also have added tests for conflicts of  --no-colour and friends. Didn't feel like doing that today, and I'll be on holiday next week, so I thought was good enough for now

### Additional tasks

- [X] Documentation for changes provided/changed
- [X] Tests added
- [X] Updated CHANGELOG.md