### PR TITLE
Remove the `cmd` parameter from `Tool`, and `cliEnvSettingsRequiredTools` from `CliEnvSettings`

### DIFF
--- a/examples/playground/Main.hs
+++ b/examples/playground/Main.hs
@@ -26,7 +26,6 @@ appSettings = Iris.defaultCliEnvSettings
         Just (Iris.defaultVersionSettings Autogen.version)
             { Iris.versionSettingsMkDesc = \v -> "Iris Example v" <> v
             }
-    , Iris.cliEnvSettingsRequiredTools = ["curl", "ghc"]
     }
 
 app :: App ()

--- a/examples/simple-grep/README.md
+++ b/examples/simple-grep/README.md
@@ -127,15 +127,12 @@ appSettings = Iris.defaultCliEnvSettings
         Just (Iris.defaultVersionSettings Autogen.version)
             { Iris.versionSettingsMkDesc = \v -> "Simple grep utility v" <> v
             }
-    , Iris.cliEnvSettingsRequiredTools = []
 
     , Iris.cliEnvSettingsCmdParser = commandsSettings
     }
 ```
 
 We describe settings for the app based on `defaultCliEnvSettings`. It helps when we don't need some option to describe, so we can just skip it. Here we can write a CLI-program description, put required tools with a list and then pass commands with the `Parser a` type from `optparse-applicative` to the `cliEnvSettingsCmdParser` field.
-
-Important to note, the `Iris.cliEnvSettingsRequiredTools` property is used by Iris for checking that system has those tools in the list, if not, it throws a `CliEnvException` exception.
 
 Following next, for ensuring about our correctness on defined commands, we would check the `--help` flag's output:
 

--- a/src/Iris/Settings.hs
+++ b/src/Iris/Settings.hs
@@ -21,7 +21,6 @@ module Iris.Settings
 import Data.Kind (Type)
 import qualified Options.Applicative as Opt
 import Iris.Cli.Version (VersionSettings)
-import Iris.Tool (Tool)
 
 {- |
 
@@ -42,10 +41,6 @@ data CliEnvSettings (cmd :: Type) (appEnv :: Type) = CliEnvSettings
 
       -- | @since 0.0.0.0
     , cliEnvSettingsVersionSettings :: Maybe VersionSettings
-
-    , cliEnvSettingsAppName :: Maybe String
-      -- | @since 0.0.0.0
-    , cliEnvSettingsRequiredTools   :: [Tool cmd]
     }
 
 
@@ -60,6 +55,4 @@ defaultCliEnvSettings = CliEnvSettings
     , cliEnvSettingsHeaderDesc      = "Simple CLI program"
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
     , cliEnvSettingsVersionSettings = Nothing
-    , cliEnvSettingsAppName         = Nothing
-    , cliEnvSettingsRequiredTools   = []
     }

--- a/src/Iris/Settings.hs
+++ b/src/Iris/Settings.hs
@@ -41,6 +41,9 @@ data CliEnvSettings (cmd :: Type) (appEnv :: Type) = CliEnvSettings
 
       -- | @since 0.0.0.0
     , cliEnvSettingsVersionSettings :: Maybe VersionSettings
+
+      -- | @since 0.0.0.0
+    , cliEnvSettingsAppName :: Maybe String
     }
 
 
@@ -54,5 +57,6 @@ defaultCliEnvSettings = CliEnvSettings
     , cliEnvSettingsAppEnv          = ()
     , cliEnvSettingsHeaderDesc      = "Simple CLI program"
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
+    , cliEnvSettingsAppName         = Nothing
     , cliEnvSettingsVersionSettings = Nothing
     }

--- a/src/Iris/Tool.hs
+++ b/src/Iris/Tool.hs
@@ -31,6 +31,7 @@ import System.Directory (findExecutable)
 import System.Process (readProcess)
 import Control.Exception (Exception, throwIO)
 import Data.Foldable (for_)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 
 import qualified Data.Text as Text
 
@@ -159,9 +160,9 @@ newtype ToolCheckException = ToolCheckException ToolCheckError
 __Throws:__ 'ToolCheckException' if can't find a tool or if it has wrong version.
 @since 0.0.0.0
 -}
-need :: [Tool] -> IO ()
+need :: MonadIO m => [Tool] -> m ()
 need tools =
     for_ tools $ \tool ->
-        checkTool tool >>= \case
+        liftIO $ checkTool tool >>= \case
             ToolOk  -> pure ()
             (ToolCheckError toolErr) -> throwIO $ ToolCheckException toolErr

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -161,8 +161,6 @@ customParserSettings parser = CliEnvSettings
     , cliEnvSettingsHeaderDesc      = "Simple CLI program"
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
     , cliEnvSettingsVersionSettings = Nothing
-    , cliEnvSettingsRequiredTools   = []
-    , cliEnvSettingsAppName         = Nothing
     }
 
 argValue :: String

--- a/test/Test/Iris/Cli.hs
+++ b/test/Test/Iris/Cli.hs
@@ -161,6 +161,7 @@ customParserSettings parser = CliEnvSettings
     , cliEnvSettingsHeaderDesc      = "Simple CLI program"
     , cliEnvSettingsProgDesc        = "CLI tool build with iris - a Haskell CLI framework"
     , cliEnvSettingsVersionSettings = Nothing
+    , cliEnvSettingsAppName         = Nothing
     }
 
 argValue :: String

--- a/test/Test/Iris/Tool.hs
+++ b/test/Test/Iris/Tool.hs
@@ -36,7 +36,7 @@ toolSpec = describe "Tool" $ do
 
         checkTool ghc100 >>= (`shouldSatisfy` isToolWrongVersion)
 
-    it "should not fail when 'need'ing 'curl'" $ need ["curl"]
+    it "should not fail when 'need'ing 'curl'" $ (need ["curl"] :: IO ())
 
     it "should fail when 'need'ing not found tools" $ do
         let tool = "xxx_unknown_executable"

--- a/test/Test/Iris/Tool.hs
+++ b/test/Test/Iris/Tool.hs
@@ -2,40 +2,56 @@ module Test.Iris.Tool (toolSpec) where
 
 import Data.Text (Text)
 import Data.Version (Version, makeVersion, parseVersion)
-import Test.Hspec (Spec, describe, it, shouldReturn, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldReturn, shouldSatisfy, shouldThrow)
 import Text.ParserCombinators.ReadP (readP_to_S)
 
-import Iris.Tool (Tool (..), ToolCheckResult (..), ToolCheckError (..), ToolSelector (..), checkTool,
-                  defaultToolSelector)
+import Iris.Tool (Tool (..), ToolCheckResult (..), ToolCheckError (..), ToolSelector (..), checkTool, ToolCheckException(..),
+                  defaultToolSelector, need)
 
 import qualified Data.Text as Text
 
+ghc100 :: Tool
+ghc100 = "ghc"
+    { toolSelector = Just defaultToolSelector
+        { toolSelectorFunction = \version -> case getVersion version of
+                Nothing -> False
+                Just v  -> v >= makeVersion [100]
+        , toolSelectorVersionArg = Just "--numeric-version"
+        }
+    }
 
 toolSpec :: Spec
 toolSpec = describe "Tool" $ do
     it "should find 'curl'" $ do
-        checkTool () "curl" `shouldReturn` ToolOk
+        checkTool "curl" `shouldReturn` ToolOk
 
     it "shouldn't find 'xxx_unknown_executable'" $ do
-        checkTool () "xxx_unknown_executable"
+        checkTool "xxx_unknown_executable"
             `shouldReturn` ToolCheckError (ToolNotFound "xxx_unknown_executable")
 
     it "shouldn't find 'ghc' version 100" $ do
-        let tool :: Tool ()
-            tool = "ghc"
-                { toolSelector = Just defaultToolSelector
-                    { toolSelectorFunction = \_cmd version -> case getVersion version of
-                          Nothing -> False
-                          Just v  -> v >= makeVersion [100]
-                    , toolSelectorVersionArg = Just "--numeric-version"
-                    }
-                }
-
         let isToolWrongVersion :: ToolCheckResult -> Bool
             isToolWrongVersion (ToolCheckError (ToolWrongVersion _)) = True
             isToolWrongVersion _other               = False
 
-        checkTool () tool >>= (`shouldSatisfy` isToolWrongVersion)
+        checkTool ghc100 >>= (`shouldSatisfy` isToolWrongVersion)
+
+    it "should not fail when 'need'ing 'curl'" $ need ["curl"]
+
+    it "should fail when 'need'ing not found tools" $ do
+        let tool = "xxx_unknown_executable"
+        let expectedExceptionSel (err :: ToolCheckException) = case err of
+                ToolCheckException (ToolNotFound e) -> e == tool
+                _other                          -> False
+
+        need [Tool tool Nothing] `shouldThrow` expectedExceptionSel
+
+    it "should fail when 'need'ing tools with wrong version" $ do
+
+        let expectedExceptionSel (err :: ToolCheckException) = case err of
+                ToolCheckException (ToolWrongVersion _) -> True
+                _other                          -> False
+        need [ghc100] `shouldThrow` expectedExceptionSel
 
 getVersion :: Text -> Maybe Version
 getVersion = extractVersion . readP_to_S parseVersion . Text.unpack

--- a/test/Test/Iris/Tool.hs
+++ b/test/Test/Iris/Tool.hs
@@ -36,7 +36,7 @@ toolSpec = describe "Tool" $ do
 
         checkTool ghc100 >>= (`shouldSatisfy` isToolWrongVersion)
 
-    it "should not fail when 'need'ing 'curl'" $ (need ["curl"] :: IO ())
+    it "should not fail when 'need'ing 'curl'" (need ["curl"] :: IO ())
 
     it "should fail when 'need'ing not found tools" $ do
         let tool = "xxx_unknown_executable"


### PR DESCRIPTION
<!-- PR title template: [#ISSUE_NUMBER] <short description>
     Example:           [#42] Solve problem X
-->

Resolves #67 

* Removes the `cmd` parameter from `Tool` (and consequently, `ToolSelector`)
* Add the `need` function, which does pretty much this: https://github.com/chshersh/iris/blob/main/src/Iris/Env.hs#L123-L126

### Additional tasks

- [ ] Documentation for changes provided/changed
  > (no docs added since I'm unsure of the final signature of `need`)
- [x] Tests added
- [ ] Updated CHANGELOG.md
  > (should I do this?)
