### PR TITLE
Tutorial: use cabal run instead of cabal exec

### DIFF
--- a/examples/simple-grep/README.md
+++ b/examples/simple-grep/README.md
@@ -387,7 +387,7 @@ Available options:
 And we can finally run it to see the result:
 
 ```shell
-$ cabal exec simple-grep -- -f iris.cabal -s iris
+$ cabal run simple-grep -- -f iris.cabal -s iris
 2: name:                iris
 7:     See [README.md](https://github.com/chshersh/iris#iris) for more details.
 8: homepage:            https://github.com/chshersh/iris


### PR DESCRIPTION
This is a bit subjective but I consider exec a more esoteric command and wouldn’t use it in a beginners tutorial unless absolutely needed. It’s also confusing when you switch between the two commands without any explanation.

note: the screenshot at the top also uses exec. I’d suggest to change that too.